### PR TITLE
Don't expect question to be on one line

### DIFF
--- a/cpp/test/part3_test.cpp
+++ b/cpp/test/part3_test.cpp
@@ -19,7 +19,8 @@ TEST(Part3, searchVideosWithNoAnswer)
     EXPECT_THAT(output, HasSubstr("Here are the results for cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, Not(HasSubstr("Playing video")));
 }
 
@@ -36,7 +37,8 @@ TEST(Part3, searchVideosAndPlayAnswer)
     EXPECT_THAT(output, HasSubstr("Here are the results for cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, HasSubstr("Playing video: Another Cat Video"));
 }
 
@@ -53,8 +55,8 @@ TEST(Part3, searchVideosAnswerOutOfBounds)
     EXPECT_THAT(output, HasSubstr("Here are the results for cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
-  
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, Not(HasSubstr("Playing video")));
 }
 
@@ -71,7 +73,8 @@ TEST(Part3, searchVideosInvalidNumber)
     EXPECT_THAT(output, HasSubstr("Here are the results for cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, Not(HasSubstr("Playing video")));
 }
 
@@ -97,7 +100,8 @@ TEST(Part3, searchVideosWithTagNoAnswer)
     EXPECT_THAT(output, HasSubstr("Here are the results for #cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, Not(HasSubstr("Playing video")));
 }
 
@@ -114,7 +118,8 @@ TEST(Part3, searchVideosWithTagPlayAnswer)
     EXPECT_THAT(output, HasSubstr("Here are the results for #cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, HasSubstr("Playing video: Amazing Cats"));
 }
 
@@ -131,7 +136,8 @@ TEST(Part3, searchVideosWithTagAnswerOutOfBounds)
     EXPECT_THAT(output, HasSubstr("Here are the results for #cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
     EXPECT_THAT(output, HasSubstr("2) Another Cat Video (another_cat_video_id)"));
-    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
     EXPECT_THAT(output, Not(HasSubstr("Playing video")));
 }
 

--- a/cpp/test/part4_test.cpp
+++ b/cpp/test/part4_test.cpp
@@ -109,7 +109,8 @@ TEST(Part4, flagVideoSearchVideos)
     EXPECT_THAT(output, HasSubstr("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
     EXPECT_THAT(output, HasSubstr("Here are the results for cat:"));
     EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
-    EXPECT_THAT(output, HasSubstr( "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a noß"));
+    EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If yes, specify the number of the video."));
+    EXPECT_THAT(output, HasSubstr("If your answer is not a valid number, we will assume it's a no."));
 }
 
 TEST(Part4, flagVideoStopVideoPlaying)

--- a/java/src/test/java/com/google/Part3Test.java
+++ b/java/src/test/java/com/google/Part3Test.java
@@ -39,7 +39,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertFalse(outputStream.toString().contains("Playing video"));
   }
 
@@ -52,7 +54,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertTrue(outputStream.toString().contains("Playing video: Another Cat Video"));
   }
 
@@ -65,7 +69,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertFalse(outputStream.toString().contains("Playing video"));
   }
 
@@ -77,7 +83,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertFalse(outputStream.toString().contains("Playing video"));
   }
 
@@ -95,7 +103,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertFalse(outputStream.toString().contains("Playing video"));
   }
 
@@ -107,7 +117,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
   }
 
@@ -119,7 +131,9 @@ public class Part3Test {
     assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
     assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no."));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
     assertFalse(outputStream.toString().contains("Playing video"));
   }
 

--- a/java/src/test/java/com/google/Part4Test.java
+++ b/java/src/test/java/com/google/Part4Test.java
@@ -121,7 +121,9 @@ public class Part4Test {
     assertTrue(outputStream.toString().contains("Here are the results for cat:"));
     assertTrue(outputStream.toString().contains("1) Another Cat Video (another_cat_video_id)"));
     assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video. If your answer is not a valid number, we will assume it's a no"));
+        "Would you like to play any of the above? If yes, specify the number of the video."));
+    assertTrue(outputStream.toString().contains(
+        "If your answer is not a valid number, we will assume it's a no."));
   }
 
   @Test

--- a/python/test/part3_test.py
+++ b/python/test/part3_test.py
@@ -11,8 +11,10 @@ def test_search_videos_with_no_answer(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert (
+               "If your answer is not a valid number, we will assume "
+               "it's a no.") in out
     assert "Playing video" not in out
 
 
@@ -26,8 +28,9 @@ def test_search_videos_and_play_answer(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert ("If your answer is not a valid number, we will assume "
+            "it's a no.") in out
     assert "Playing video: Another Cat Video" in out
 
 
@@ -41,8 +44,9 @@ def test_search_videos_number_out_of_bounds(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert ("If your answer is not a valid number, we will assume "
+            "it's a no.") in out
     assert "Playing video" not in out
 
 
@@ -56,8 +60,9 @@ def test_search_videos_invalid_number(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert ("If your answer is not a valid number, we will assume "
+            "it's a no.") in out
     assert "Playing video" not in out
 
 
@@ -77,8 +82,9 @@ def test_search_videos_with_tag_no_answer(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert ("If your answer is not a valid number, we will assume "
+            "it's a no.") in out
 
 
 @mock.patch('builtins.input', lambda *args: '1')
@@ -90,8 +96,9 @@ def test_search_videos_with_tag_play_answered_number(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert ("If your answer is not a valid number, we will assume "
+            "it's a no.") in out
     assert "Playing video: Amazing Cats" in out
 
 
@@ -104,8 +111,9 @@ def test_search_videos_with_tag_number_out_of_bounds(capfd):
     assert "1) Amazing Cats (amazing_cats_video_id)" in out
     assert "2) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a "
-            "valid number, we will assume it's a no.") in out
+            "specify the number of the video.") in out
+    assert ("If your answer is not a valid number, we will assume "
+            "it's a no.") in out
     assert "Playing video" not in out
 
 

--- a/python/test/part4_test.py
+++ b/python/test/part4_test.py
@@ -102,8 +102,9 @@ def test_flag_video_search_videos(capfd):
     assert "Here are the results for cat:" in out
     assert "1) Another Cat Video (another_cat_video_id)" in out
     assert ("Would you like to play any of the above? If yes, "
-            "specify the number of the video. If your answer is not a valid "
-            "number, we will assume it's a no") in out
+            "specify the number of the video.") in out
+    assert("If your answer is not a valid number, we will assume "
+           "it's a no.") in out
 
 
 def test_flag_video_stop_video_playing(capfd):


### PR DESCRIPTION
In the instructions they are on 2 lines (due to the line break). We can adjust the tests to check the string in two asserts, in which case it won't matter if the people implement it on one, or two lines.