### PR TITLE
Fix MSVC warning

### DIFF
--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -33,7 +33,8 @@ int main() {
         commandList.push_back(command);
       }
       std::transform(commandList[0].begin(), commandList[0].end(),
-                     commandList[0].begin(), ::toupper);
+                     commandList[0].begin(),
+                     [](auto c) { return static_cast<char>(std::toupper(c)); });
       if (commandList[0] == "EXIT") {
         break;
       }


### PR DESCRIPTION
toupper takes an integer and returns an integer. MSVC warns about the
loss of precision when returning a character.