### PR TITLE
Reduce cmake version requirement to 3.14

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
Manually tested that 3.14 is sufficient. 3.20 is pretty recent and may
not be available on all systems through the standard package manager.
3.13 didn't work due to FetchContent_MakeAvailable.