### PR TITLE
Fix build issues

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,6 +25,8 @@ else()
       -Wno-unused-parameter)
 endif()
 
+file(COPY src/videos.txt DESTINATION src/)
+
 add_executable(youtube
     src/commandparser.cpp
     src/helper.cpp

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -34,7 +34,7 @@ int main() {
       }
       std::transform(commandList[0].begin(), commandList[0].end(),
                      commandList[0].begin(),
-                     [](auto c) { return static_cast<char>(std::toupper(c)); });
+                     [](char c) { return static_cast<char>(std::toupper(c)); });
       if (commandList[0] == "EXIT") {
         break;
       }


### PR DESCRIPTION
Fix build issues in cpp code:

- Using auto in lambda function results in build error, so the correct char type is used instead.
- src.txt should be copied over to build folder to ensure that the file can be opened while running tests.