### PR TITLE
Link all C++ classes into the unit tests

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ FetchContent_Declare(
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+include(GoogleTest)
 
 if(MSVC)
   add_compile_options(/Wall)
@@ -27,86 +28,34 @@ endif()
 
 file(COPY src/videos.txt DESTINATION src/)
 
-add_executable(youtube
+add_library(youtube_lib
     src/commandparser.cpp
     src/helper.cpp
     src/video.cpp
     src/videoplayer.cpp
-    src/videolibrary.cpp
-    src/main.cpp)   
+    src/videolibrary.cpp)
+
+add_executable(youtube src/main.cpp)
+target_link_libraries(youtube youtube_lib)
 
 enable_testing()
 
-add_executable(
-  part1_test
-  test/part1_test.cpp
-  src/videoplayer.cpp
-)
-
-add_executable(
-  part2_test
-  test/part2_test.cpp
-  src/videoplayer.cpp
-)
-
-add_executable(
-  part3_test
-  test/part3_test.cpp
-  src/videoplayer.cpp
-)
-
-add_executable(
-  part4_test
-  test/part4_test.cpp
-  src/videoplayer.cpp
-)
-
-add_executable(
-  videolibrary_test
-  test/videolibrary_test.cpp
-  src/videolibrary.cpp
-  src/video.cpp
-  src/helper.cpp
-)
-
-target_link_libraries(
-  part1_test
-  gmock
-  gtest
-  gtest_main
-)
-
-target_link_libraries(
-  part2_test
-  gmock
-  gtest
-  gtest_main
-)
-
-target_link_libraries(
-  part3_test
-  gmock
-  gtest
-  gtest_main
-)
-
-target_link_libraries(
-  part4_test
-  gmock
-  gtest
-  gtest_main
-)
-
-target_link_libraries(
-  videolibrary_test
-  gmock
-  gtest
-  gtest_main
-)
-
-include(GoogleTest)
+add_executable(part1_test test/part1_test.cpp)
+target_link_libraries(part1_test youtube_lib gmock gtest gtest_main)
 gtest_discover_tests(part1_test)
+
+add_executable(part2_test test/part2_test.cpp)
+target_link_libraries(part2_test youtube_lib gmock gtest gtest_main)
 gtest_discover_tests(part2_test)
+
+add_executable(part3_test test/part3_test.cpp)
+target_link_libraries(part3_test youtube_lib gmock gtest gtest_main)
 gtest_discover_tests(part3_test)
+
+add_executable(part4_test test/part4_test.cpp)
+target_link_libraries(part4_test youtube_lib gmock gtest gtest_main)
 gtest_discover_tests(part4_test)
+
+add_executable(videolibrary_test test/videolibrary_test.cpp)
+target_link_libraries(videolibrary_test youtube_lib gmock gtest gtest_main)
 gtest_discover_tests(videolibrary_test)


### PR DESCRIPTION
Change the C++ build file to compile all classes into tests to avoid
linker errors when adding functionality.