### PR TITLE
Updating all Java tests to assertTrue to assertEquals

### DIFF
--- a/java/src/test/java/com/google/Part1Test.java
+++ b/java/src/test/java/com/google/Part1Test.java
@@ -29,21 +29,20 @@ public class Part1Test {
   @Test
   public void testNumberOfVideos() {
     videoPlayer.numberOfVideos();
-    assertTrue(outputStream.toString().contains("5 videos in the library"));
+    assertEquals("5 videos in the library\n", outputStream.toString());
   }
 
   @Test
   public void testShowAllVideos() {
     videoPlayer.showAllVideos();
-    assertTrue(outputStream.toString().contains("Here's a list of all available videos:"));
-    assertTrue(
-        outputStream.toString().contains("Amazing Cats (amazing_cats_video_id) [#cat #animal]"));
-    assertTrue(outputStream.toString()
-        .contains("Another Cat Video (another_cat_video_id) [#cat #animal]"));
-    assertTrue(outputStream.toString().contains("Funny Dogs (funny_dogs_video_id) [#dog #animal]"));
-    assertTrue(outputStream.toString()
-        .contains("Life at Google (life_at_google_video_id) [#google #career]"));
-    assertTrue(outputStream.toString().contains("Video about nothing (nothing_video_id) []"));
+
+    assertEquals("Here's a list of all available videos:\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal]\n"
+            + "Another Cat Video (another_cat_video_id) [#cat #animal]\n"
+            + "Funny Dogs (funny_dogs_video_id) [#dog #animal]\n"
+            + "Life at Google (life_at_google_video_id) [#google #career]\n"
+            + "Video about nothing (nothing_video_id) []\n"
+        , outputStream.toString());
 
     List<String> outputList = new ArrayList<>(Arrays.asList(outputStream.toString().split("\n")));
     outputList.remove(0);
@@ -55,29 +54,35 @@ public class Part1Test {
   @Test
   public void testPlayVideo() {
     videoPlayer.playVideo("amazing_cats_video_id");
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
+    assertEquals(outputStream.toString(),"Playing video: Amazing Cats\n");
   }
 
   @Test
   public void testPlayVideoNonExistent() {
     videoPlayer.playVideo("some_other_video_that_doesnt_exist");
-    assertTrue(outputStream.toString().contains("Cannot play video: Video does not exist"));
+    assertEquals("Cannot play video: Video does not exist\n", outputStream.toString());
   }
 
   @Test
   public void testPlayVideoStopPrevious() {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.playVideo("funny_dogs_video_id");
-    assertTrue(outputStream.toString().contains("Stopping video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Playing video: Funny Dogs"));
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Stopping video: Amazing Cats\n"
+            + "Playing video: Funny Dogs\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testPlayVideoDontStopPreviousIfNonExistent() {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.playVideo("some_other_video");
+
     assertFalse(outputStream.toString().contains("Stopping video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Cannot play video: Video does not exist"));
+
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Cannot play video: Video does not exist\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -85,8 +90,9 @@ public class Part1Test {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.stopVideo();
 
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Stopping video: Amazing Cats"));
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Stopping video: Amazing Cats\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -95,17 +101,16 @@ public class Part1Test {
     videoPlayer.stopVideo();
     videoPlayer.stopVideo();
 
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Stopping video: Amazing Cats"));
-    assertTrue(
-        outputStream.toString().contains("Cannot stop video: No video is currently playing"));
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Stopping video: Amazing Cats\n"
+            + "Cannot stop video: No video is currently playing\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testStopVideoNothingPlaying() {
     videoPlayer.stopVideo();
-    assertTrue(
-        outputStream.toString().contains("Cannot stop video: No video is currently playing"));
+    assertEquals("Cannot stop video: No video is currently playing\n", outputStream.toString());
   }
 
   @Test
@@ -136,23 +141,27 @@ public class Part1Test {
   public void testShowPlaying() {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.showPlaying();
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString()
-        .contains("Currently playing: Amazing Cats (amazing_cats_video_id) [#cat #animal]"));
+
+    assertEquals(outputStream.toString(),
+        "Playing video: Amazing Cats\n"
+            + "Currently playing: Amazing Cats (amazing_cats_video_id) [#cat #animal]\n");
   }
 
   @Test
   public void testShowNothingPlaying() {
     videoPlayer.showPlaying();
-    assertTrue(outputStream.toString().contains("No video is currently playing"));
+
+    assertEquals("No video is currently playing\n", outputStream.toString());
   }
 
   @Test
   public void testPauseVideo() {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.pauseVideo();
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Pausing video: Amazing Cats"));
+
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Pausing video: Amazing Cats\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -160,28 +169,18 @@ public class Part1Test {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.pauseVideo();
     videoPlayer.showPlaying();
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Pausing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains(
-        "Currently playing: Amazing Cats (amazing_cats_video_id) [#cat #animal] - PAUSED"));
-  }
 
-  @Test
-  public void testPauseVideoPlayVideo() {
-    videoPlayer.playVideo("amazing_cats_video_id");
-    videoPlayer.pauseVideo();
-    videoPlayer.playVideo("amazing_cats_video_id");
-    videoPlayer.showPlaying();
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Pausing video: Amazing Cats"));
-    assertFalse(outputStream.toString().contains("PAUSED"));
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Pausing video: Amazing Cats\n"
+            + "Currently playing: Amazing Cats (amazing_cats_video_id) [#cat #animal] - PAUSED\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testPauseVideoNothingPlaying() {
     videoPlayer.pauseVideo();
-    assertTrue(
-        outputStream.toString().contains("Cannot pause video: No video is currently playing"));
+
+    assertEquals("Cannot pause video: No video is currently playing\n", outputStream.toString());
   }
 
   @Test
@@ -189,23 +188,28 @@ public class Part1Test {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.pauseVideo();
     videoPlayer.continueVideo();
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Pausing video: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Continuing video: Amazing Cats"));
+
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Pausing video: Amazing Cats\n"
+            + "Continuing video: Amazing Cats\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testContinueVideoNotPaused() {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.continueVideo();
-    assertTrue(outputStream.toString()
-        .contains("Cannot continue video: Video is not paused"));
+
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Cannot continue video: Video is not paused\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testContinueVideoNothingPlaying() {
     videoPlayer.continueVideo();
-    assertTrue(
-        outputStream.toString().contains("Cannot continue video: No video is currently playing"));
+
+    assertEquals("Cannot continue video: No video is currently playing\n"
+        , outputStream.toString());
   }
 }

--- a/java/src/test/java/com/google/Part2Test.java
+++ b/java/src/test/java/com/google/Part2Test.java
@@ -26,24 +26,25 @@ public class Part2Test {
   @Test
   public void testCreatePlaylist() {
     videoPlayer.createPlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
+    assertEquals("Successfully created new playlist: my_playlist\n", outputStream.toString());
   }
 
   @Test
   public void testCreateExistingPlaylist() {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.createPlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString()
-        .contains("Cannot create playlist: A playlist with the same name already exists"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Cannot create playlist: A playlist with the same name already exists\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testAddToPlaylist() {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -51,10 +52,10 @@ public class Part2Test {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(
-        outputStream.toString().contains("Cannot add video to my_playlist: Video already added"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Cannot add video to my_playlist: Video already added\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -62,22 +63,22 @@ public class Part2Test {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.addVideoToPlaylist("my_playlist", "some_other_video_id");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString()
-        .contains("Cannot add video to my_playlist: Video does not exist"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Cannot add video to my_playlist: Video does not exist\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testAddVideoToPlaylistNonExistent() {
     videoPlayer.addVideoToPlaylist("another_playlist", "amazing_cats_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Cannot add video to another_playlist: Playlist does not exist"));
+    assertEquals("Cannot add video to another_playlist: Playlist does not exist\n", outputStream.toString());
   }
 
   @Test
   public void testShowAllPlaylistsNoPlaylistsExist() {
     videoPlayer.showAllPlaylists();
-    assertTrue(outputStream.toString().contains("No playlists exist yet"));
+    assertEquals("No playlists exist yet\n", outputStream.toString());
   }
 
   @Test
@@ -85,9 +86,13 @@ public class Part2Test {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.createPlaylist("another_playlist");
     videoPlayer.showAllPlaylists();
-    assertTrue(outputStream.toString().contains("Showing all playlists:"));
-    assertTrue(outputStream.toString().contains("my_playlist"));
-    assertTrue(outputStream.toString().contains("another_playlist"));
+
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Successfully created new playlist: another_playlist\n"
+            + "Showing all playlists:\n"
+            + "another_playlist\n"
+            + "my_playlist\n"
+        , outputStream.toString());
 
     List<String> outputList = new ArrayList<>(Arrays.asList(outputStream.toString().split("\n")));
     outputList = outputList.subList(outputList.size() - 2, outputList.size());
@@ -102,20 +107,20 @@ public class Part2Test {
     videoPlayer.showPlaylist("my_playlist");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.showPlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Showing playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("No videos here yet"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Showing playlist: my_playlist"));
-    assertTrue(
-        outputStream.toString().contains("Amazing Cats (amazing_cats_video_id) [#cat #animal]"));
+
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Showing playlist: my_playlist\n"
+            + "No videos here yet\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Showing playlist: my_playlist\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal]\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testShowPlaylistNonExistent() throws Exception {
     videoPlayer.showPlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains(
-        "Cannot show playlist my_playlist: Playlist does not exist"));
+    assertEquals("Cannot show playlist my_playlist: Playlist does not exist\n", outputStream.toString());
   }
 
   @Test
@@ -124,19 +129,21 @@ public class Part2Test {
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.removeFromPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.removeFromPlaylist("my_playlist", "amazing_cats_video_id");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Removed video from my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString()
-        .contains("Cannot remove video from my_playlist: Video is not in playlist"));
+
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Removed video from my_playlist: Amazing Cats\n"
+            + "Cannot remove video from my_playlist: Video is not in playlist\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testRemoveFromPlaylistVideoNotInPlaylist() {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.removeFromPlaylist("my_playlist", "amazing_cats_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Cannot remove video from my_playlist: Video is not in playlist"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Cannot remove video from my_playlist: Video is not in playlist\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -144,17 +151,16 @@ public class Part2Test {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.removeFromPlaylist("my_playlist", "some_other_video_id");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString()
-        .contains("Cannot remove video from my_playlist: Video does not exist"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Cannot remove video from my_playlist: Video does not exist\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testRemoveFromPlaylistNonexistentPlaylist() throws Exception {
     videoPlayer.removeFromPlaylist("my_cool_playlist", "some_other_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Cannot remove video from my_cool_playlist: Playlist does not exist"));
+    assertEquals("Cannot remove video from my_cool_playlist: Playlist does not exist\n", outputStream.toString());
   }
 
   @Test
@@ -165,36 +171,36 @@ public class Part2Test {
     videoPlayer.clearPlaylist("my_playlist");
     videoPlayer.showPlaylist("my_playlist");
 
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString().contains("Showing playlist: my_playlist"));
-    assertTrue(
-        outputStream.toString().contains("Amazing Cats (amazing_cats_video_id) [#cat #animal]"));
-    assertTrue(
-        outputStream.toString().contains("Successfully removed all videos from my_playlist"));
-    assertTrue(outputStream.toString().contains("Showing playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("No videos here yet"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Showing playlist: my_playlist\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal]\n"
+            + "Successfully removed all videos from my_playlist\n"
+            + "Showing playlist: my_playlist\n"
+            + "No videos here yet\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testClearPlaylistNonexistent() {
     videoPlayer.clearPlaylist("my_playlist");
-    assertTrue(outputStream.toString()
-        .contains("Cannot clear playlist my_playlist: Playlist does not exist"));
+    assertEquals("Cannot clear playlist my_playlist: Playlist does not exist\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testDeletePlaylist() {
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.deletePlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Deleted playlist: my_playlist"));
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Deleted playlist: my_playlist\n"
+        , outputStream.toString());
   }
 
   @Test
   public void test_delete_playlist_nonexistent() {
     videoPlayer.deletePlaylist("my_playlist");
-    assertTrue(outputStream.toString()
-        .contains("Cannot delete playlist my_playlist: Playlist does not exist"));
+    assertEquals("Cannot delete playlist my_playlist: Playlist does not exist\n"
+        , outputStream.toString());
   }
 }

--- a/java/src/test/java/com/google/Part3Test.java
+++ b/java/src/test/java/com/google/Part3Test.java
@@ -1,5 +1,6 @@
 package com.google;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,14 +36,14 @@ public class Part3Test {
     System.setIn(new ByteArrayInputStream("No\r\n".getBytes()));
 
     videoPlayer.searchVideos("cat");
-    assertTrue(outputStream.toString().contains("Here are the results for cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertFalse(outputStream.toString().contains("Playing video"));
+
+    assertEquals("Here are the results for cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+        , outputStream.toString());
+
   }
 
   @Test
@@ -50,14 +51,14 @@ public class Part3Test {
     System.setIn(new ByteArrayInputStream("2\r\n".getBytes()));
 
     videoPlayer.searchVideos("cat");
-    assertTrue(outputStream.toString().contains("Here are the results for cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertTrue(outputStream.toString().contains("Playing video: Another Cat Video"));
+
+    assertEquals("Here are the results for cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+            + "Playing video: Another Cat Video\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -65,81 +66,78 @@ public class Part3Test {
     System.setIn(new ByteArrayInputStream("5\r\n".getBytes()));
 
     videoPlayer.searchVideos("cat");
-    assertTrue(outputStream.toString().contains("Here are the results for cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertFalse(outputStream.toString().contains("Playing video"));
+
+    assertEquals("Here are the results for cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testSearchVideosInvalidNumber() {
     System.setIn(new ByteArrayInputStream("ab3g\r\n".getBytes()));
     videoPlayer.searchVideos("cat");
-    assertTrue(outputStream.toString().contains("Here are the results for cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertFalse(outputStream.toString().contains("Playing video"));
+
+    assertEquals("Here are the results for cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testSearchVideosNoResults() {
     videoPlayer.searchVideos("blah");
-    assertTrue(outputStream.toString().contains("No search results for blah"));
+    assertEquals("No search results for blah\n", outputStream.toString());
   }
 
   @Test
   public void testSearchVideosWithTagNoAnswer() {
     System.setIn(new ByteArrayInputStream("no\r\n".getBytes()));
     videoPlayer.searchVideosWithTag("#cat");
-    assertTrue(outputStream.toString().contains("Here are the results for #cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertFalse(outputStream.toString().contains("Playing video"));
+
+    assertEquals("Here are the results for #cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testSearchVideosWithTagPlayAnswer() {
     System.setIn(new ByteArrayInputStream("1\r\n".getBytes()));
     videoPlayer.searchVideosWithTag("#cat");
-    assertTrue(outputStream.toString().contains("Here are the results for #cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
+
+    assertEquals("Here are the results for #cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+            + "Playing video: Amazing Cats\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testSearchVideosWithTagAnswerOutOfBounds() {
     System.setIn(new ByteArrayInputStream("5\r\n".getBytes()));
     videoPlayer.searchVideosWithTag("#cat");
-    assertTrue(outputStream.toString().contains("Here are the results for #cat:"));
-    assertTrue(outputStream.toString().contains("1) Amazing Cats (amazing_cats_video_id)"));
-    assertTrue(outputStream.toString().contains("2) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
-    assertFalse(outputStream.toString().contains("Playing video"));
+
+    assertEquals("Here are the results for #cat:\n"
+            + "1) Amazing Cats (amazing_cats_video_id)\n"
+            + "2) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testSearchVideosWithTagNoResults() {
     videoPlayer.searchVideosWithTag("#blah");
-    assertTrue(outputStream.toString().contains("No search results for #blah"));
+
+    assertEquals("No search results for #blah\n", outputStream.toString());
   }
 }

--- a/java/src/test/java/com/google/Part4Test.java
+++ b/java/src/test/java/com/google/Part4Test.java
@@ -1,5 +1,6 @@
 package com.google;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -31,40 +32,42 @@ public class Part4Test {
   @Test
   public void testFlagVideoWithReason() {
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
+
+    assertEquals("Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n", outputStream.toString());
   }
 
   @Test
   public void testFlagVideoWithoutReason() {
     videoPlayer.flagVideo("another_cat_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Another Cat Video (reason: Not supplied)"));
+
+    assertEquals("Successfully flagged video: Another Cat Video (reason: Not supplied)\n", outputStream.toString());
   }
 
   @Test
   public void testFlagVideoAlreadyFlagged() {
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString().contains("Cannot flag video: Video is already flagged"));
+
+    assertEquals("Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Cannot flag video: Video is already flagged\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testFlagVideoNonexistent() {
     videoPlayer.flagVideo("video_does_not_exist", "flagVideo_reason");
-    assertTrue(outputStream.toString().contains("Cannot flag video: Video does not exist"));
+
+    assertEquals("Cannot flag video: Video does not exist\n", outputStream.toString());
   }
 
   @Test
   public void testFlagVideoCanNoLongerPlay() {
     videoPlayer.flagVideo("amazing_cats_video_id");
     videoPlayer.playVideo("amazing_cats_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: Not supplied)"));
-    assertTrue(outputStream.toString()
-        .contains("Cannot play video: Video is currently flagged (reason: Not supplied)"));
+
+    assertEquals("Successfully flagged video: Amazing Cats (reason: Not supplied)\n"
+            + "Cannot play video: Video is currently flagged (reason: Not supplied)\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -72,11 +75,11 @@ public class Part4Test {
     videoPlayer.flagVideo("amazing_cats_video_id");
     videoPlayer.createPlaylist("my_playlist");
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: Not supplied)"));
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains(
-        "Cannot add video to my_playlist: Video is currently flagged (reason: Not supplied)"));
+
+    assertEquals("Successfully flagged video: Amazing Cats (reason: Not supplied)\n"
+            + "Successfully created new playlist: my_playlist\n"
+            + "Cannot add video to my_playlist: Video is currently flagged (reason: Not supplied)\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -85,13 +88,13 @@ public class Part4Test {
     videoPlayer.addVideoToPlaylist("my_playlist", "amazing_cats_video_id");
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
     videoPlayer.showPlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString().contains("Showing playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains(
-        "Amazing Cats (amazing_cats_video_id) [#cat #animal] - FLAGGED (reason: dont_like_cats)"));
+
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Showing playlist: my_playlist\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal] - FLAGGED (reason: dont_like_cats)\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -99,16 +102,14 @@ public class Part4Test {
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
     videoPlayer.showAllVideos();
 
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString().contains("Here's a list of all available videos:"));
-    assertTrue(outputStream.toString().contains(
-        "Amazing Cats (amazing_cats_video_id) [#cat #animal] - FLAGGED (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString()
-        .contains("Another Cat Video (another_cat_video_id) [#cat #animal]"));
-    assertTrue(outputStream.toString().contains("Funny Dogs (funny_dogs_video_id) [#dog #animal]"));
-    assertTrue(outputStream.toString()
-        .contains("Life at Google (life_at_google_video_id) [#google #career]"));
+    assertEquals("Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Here's a list of all available videos:\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal] - FLAGGED (reason: dont_like_cats)\n"
+            + "Another Cat Video (another_cat_video_id) [#cat #animal]\n"
+            + "Funny Dogs (funny_dogs_video_id) [#dog #animal]\n"
+            + "Life at Google (life_at_google_video_id) [#google #career]\n"
+            + "Video about nothing (nothing_video_id) []\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -116,14 +117,13 @@ public class Part4Test {
     System.setIn(new ByteArrayInputStream("No\r\n".getBytes()));
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
     videoPlayer.searchVideos("cat");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString().contains("Here are the results for cat:"));
-    assertTrue(outputStream.toString().contains("1) Another Cat Video (another_cat_video_id)"));
-    assertTrue(outputStream.toString().contains(
-        "Would you like to play any of the above? If yes, specify the number of the video."));
-    assertTrue(outputStream.toString().contains(
-        "If your answer is not a valid number, we will assume it's a no."));
+
+    assertEquals("Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Here are the results for cat:\n"
+            + "1) Another Cat Video (another_cat_video_id)\n"
+            + "Would you like to play any of the above? If yes, specify the number of the video. \n"
+            + "If your answer is not a valid number, we will assume it's a no.\n\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -131,35 +131,32 @@ public class Part4Test {
     videoPlayer.playVideo("amazing_cats_video_id");
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
     videoPlayer.showPlaying();
-    assertTrue(outputStream.toString().contains("Playing video: Amazing Cats"));
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString().contains("No video is currently playing"));
+
+    assertEquals("Playing video: Amazing Cats\n"
+            + "Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Stopping video: Amazing Cats\n"
+            + "No video is currently playing\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testAllowVideo() {
     videoPlayer.flagVideo("amazing_cats_video_id", "dont_like_cats");
     videoPlayer.allowVideo("amazing_cats_video_id");
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(
-        outputStream.toString().contains("Successfully removed flag from video: Amazing Cats"));
+
+    assertEquals("Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Successfully removed flag from video: Amazing Cats\n"
+        , outputStream.toString());
   }
 
   @Test
   public void testAllowVideoNotFlagged() {
     videoPlayer.allowVideo("amazing_cats_video_id");
     videoPlayer.showPlaying();
-    assertTrue(
-        outputStream.toString().contains("Cannot remove flag from video: Video is not flagged"));
-  }
 
-  @Test
-  public void testAllowVideoNonexistent() {
-    videoPlayer.allowVideo("video_does_not_exist");
-    assertTrue(
-        outputStream.toString().contains("Cannot remove flag from video: Video does not exist"));
+    assertEquals("Cannot remove flag from video: Video is not flagged\n"
+            + "No video is currently playing\n"
+        , outputStream.toString());
   }
 
   @Test
@@ -170,16 +167,15 @@ public class Part4Test {
     videoPlayer.showPlaylist("my_playlist");
     videoPlayer.allowVideo("amazing_cats_video_id");
     videoPlayer.showPlaylist("my_playlist");
-    assertTrue(outputStream.toString().contains("Successfully created new playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains("Added video to my_playlist: Amazing Cats"));
-    assertTrue(outputStream.toString()
-        .contains("Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-    assertTrue(outputStream.toString().contains("Showing playlist: my_playlist"));
-    assertTrue(outputStream.toString().contains(
-        "Amazing Cats (amazing_cats_video_id) [#cat #animal] - FLAGGED (reason: dont_like_cats)"));
-    assertTrue(
-        outputStream.toString().contains("Successfully removed flag from video: Amazing Cats"));
-    assertTrue(
-        outputStream.toString().contains("Amazing Cats (amazing_cats_video_id) [#cat #animal]"));
+
+    assertEquals("Successfully created new playlist: my_playlist\n"
+            + "Added video to my_playlist: Amazing Cats\n"
+            + "Successfully flagged video: Amazing Cats (reason: dont_like_cats)\n"
+            + "Showing playlist: my_playlist\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal] - FLAGGED (reason: dont_like_cats)\n"
+            + "Successfully removed flag from video: Amazing Cats\n"
+            + "Showing playlist: my_playlist\n"
+            + "Amazing Cats (amazing_cats_video_id) [#cat #animal]\n"
+        , outputStream.toString());
   }
 }


### PR DESCRIPTION
The current tests are a little mean, they use AssertTrue and compare two strings by looking for "contains", by default when the test fails you will get a true/false mismatch but not the strings themselves (the most helpful part to help you identify what is going wrong). As there are lots of very similar strings requested to be output as part of the tasks I had to manually update the tests while attempting the challenge to add assertEquals to help me work out what the problem was.

I feel this is a key update to assist with anyone taking the assignment and wanted to share this PR as a result :)