### PR TITLE
Fix issues in cpp tests

### DIFF
--- a/cpp/test/part1_test.cpp
+++ b/cpp/test/part1_test.cpp
@@ -173,7 +173,7 @@ TEST(Part1, pauseVideoPlayVideo) {
   testing::internal::CaptureStdout();
   videoPlayer.playVideo("amazing_cats_video_id");
   videoPlayer.pauseVideo();
-  videoPlayer.playVideo("amazing_cats_video_id")
+  videoPlayer.playVideo("amazing_cats_video_id");
   videoPlayer.showPlaying();
   std::string output = testing::internal::GetCapturedStdout();
   EXPECT_THAT(output, HasSubstr("Playing video: Amazing Cats"));
@@ -188,6 +188,17 @@ TEST(Part1, pauseVideoNothingPlaying) {
   std::string output = testing::internal::GetCapturedStdout();
   EXPECT_THAT(output,
               HasSubstr("Cannot pause video: No video is currently playing"));
+}
+
+TEST(Part1, pauseVideoTwice) {
+  VideoPlayer videoPlayer = VideoPlayer();
+  testing::internal::CaptureStdout();
+  videoPlayer.playVideo("amazing_cats_video_id");
+  videoPlayer.pauseVideo();
+  videoPlayer.pauseVideo();
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_THAT(output,
+              HasSubstr("Video already paused: Amazing Cats"));
 }
 
 TEST(Part1, continueVideo) {

--- a/cpp/test/part2_test.cpp
+++ b/cpp/test/part2_test.cpp
@@ -97,6 +97,7 @@ TEST(Part2, showAllPlaylist) {
   EXPECT_THAT(output, HasSubstr("Showing all playlists:"));
   EXPECT_THAT(output, HasSubstr("my_playlist"));
   EXPECT_THAT(output, HasSubstr("another_playlist"));
+  EXPECT_TRUE(output.find("another_playlist") < output.find("my_playlist"));
 }
 
 TEST(Part2, showPlaylist) {
@@ -158,7 +159,7 @@ TEST(Part2, removeFromPlaylistVideoNotInPlaylist) {
           "Cannot remove video from my_playlist: Video is not in playlist"));
 }
 
-TEST(Part2, removeFromPlaylistNonexistantVideo) {
+TEST(Part2, removeFromPlaylistNonexistentVideo) {
   VideoPlayer videoPlayer = VideoPlayer();
   testing::internal::CaptureStdout();
   videoPlayer.createPlaylist("my_playlist");
@@ -203,7 +204,7 @@ TEST(Part2, clearPlaylist) {
   EXPECT_THAT(output, HasSubstr("No videos here yet"));
 }
 
-TEST(Part2, clearPlaylistNonexistant) {
+TEST(Part2, clearPlaylistNonexistent) {
   VideoPlayer videoPlayer = VideoPlayer();
   testing::internal::CaptureStdout();
   videoPlayer.clearPlaylist("my_playlist");
@@ -224,7 +225,7 @@ TEST(Part2, deletePlaylist) {
   EXPECT_THAT(output, HasSubstr("Deleted playlist: my_playlist"));
 }
 
-TEST(Part2, deletePlaylistNonexistant) {
+TEST(Part2, deletePlaylistNonexistent) {
   VideoPlayer videoPlayer = VideoPlayer();
   testing::internal::CaptureStdout();
   videoPlayer.deletePlaylist("my_playlist");

--- a/cpp/test/part4_test.cpp
+++ b/cpp/test/part4_test.cpp
@@ -36,7 +36,7 @@ TEST(Part4, flagVideoAlreadyFlagged) {
       output,
       HasSubstr(
           "Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
-  EXPECT_THAT(output, HasSubstr("Cannot flag video: Video already flagged"));
+  EXPECT_THAT(output, HasSubstr("Cannot flag video: Video is already flagged"));
 }
 
 TEST(Part4, flagVideoNonexistent) {
@@ -133,13 +133,14 @@ TEST(Part4, flagVideoSearchVideos) {
       HasSubstr(
           "Successfully flagged video: Amazing Cats (reason: dont_like_cats)"));
   EXPECT_THAT(output, HasSubstr("Here are the results for cat:"));
-  EXPECT_THAT(output, HasSubstr("1) Amazing Cats (amazing_cats_video_id)"));
+  EXPECT_THAT(output, HasSubstr("1) Another Cat Video (another_cat_video_id)"));
   EXPECT_THAT(output, HasSubstr("Would you like to play any of the above? If "
                                 "yes, specify the number of the video."));
   EXPECT_THAT(
       output,
       HasSubstr(
           "If your answer is not a valid number, we will assume it's a no."));
+  EXPECT_THAT(output, Not(HasSubstr("Amazing Cats (amazing_cats_video_id)")));
 }
 
 TEST(Part4, flagVideoStopVideoPlaying) {


### PR DESCRIPTION
Fixes issues in cpp tests:

- Missing semicolon
- Check the order of output is lexicographical for showAllPlaylist command.
- Search output should not contain flagged video.

Add a new test to check the results of pausing a video twice.