### PR TITLE
Add C++ header files to CMakeLists.txt

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -30,10 +30,16 @@ file(COPY src/videos.txt DESTINATION src/)
 
 add_library(youtube_lib
     src/commandparser.cpp
+    src/commandparser.h
     src/helper.cpp
+    src/helper.h
     src/video.cpp
+    src/video.h
+    src/videolibrary.cpp
+    src/videolibrary.h
     src/videoplayer.cpp
-    src/videolibrary.cpp)
+    src/videoplayer.h
+    src/videoplaylist.h)
 
 add_executable(youtube src/main.cpp)
 target_link_libraries(youtube youtube_lib)


### PR DESCRIPTION
C++ header files are part of the project and should be included in `CMakeLists.txt`, so they show up in development environments like Microsoft Visual Studio.