### PR TITLE
Fix instance moving and refactor member variables

### DIFF
--- a/cpp/src/commandparser.cpp
+++ b/cpp/src/commandparser.cpp
@@ -2,11 +2,12 @@
 
 #include <iostream>
 #include <sstream>
+#include <utility>
 #include <vector>
 
-CommandParser::CommandParser(VideoPlayer&& vp) : videoPlayer{vp} {}
+CommandParser::CommandParser(VideoPlayer&& vp) : video_player_(std::move(vp)) {}
 
-void CommandParser::executeCommand(std::vector<std::string> command) {
+void CommandParser::executeCommand(std::vector<std::string> const& command) {
   if (command.empty()) {
     std::cout << "No commands passed in to executeCommand, that is unexpected"
               << std::endl;
@@ -14,32 +15,32 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
   }
 
   if (command[0] == "NUMBER_OF_VIDEOS") {
-    videoPlayer.numberOfVideos();
+    video_player_.numberOfVideos();
   } else if (command[0] == "SHOW_ALL_VIDEOS") {
-    videoPlayer.showAllVideos();
+    video_player_.showAllVideos();
   } else if (command[0] == "PLAY") {
     if (command.size() != 2) {
       std::cout << "Please enter PLAY command followed by video_id."
                 << std::endl;
     } else {
-      videoPlayer.playVideo(command[1]);
+      video_player_.playVideo(command[1]);
     }
   } else if (command[0] == "PLAY_RANDOM") {
-    videoPlayer.playRandomVideo();
+    video_player_.playRandomVideo();
   } else if (command[0] == "STOP") {
-    videoPlayer.stopVideo();
+    video_player_.stopVideo();
   } else if (command[0] == "PAUSE") {
-    videoPlayer.pauseVideo();
+    video_player_.pauseVideo();
   } else if (command[0] == "CONTINUE") {
-    videoPlayer.continueVideo();
+    video_player_.continueVideo();
   } else if (command[0] == "SHOW_PLAYING") {
-    videoPlayer.showPlaying();
+    video_player_.showPlaying();
   } else if (command[0] == "CREATE_PLAYLIST") {
     if (command.size() != 2) {
       std::cout << "Please enter CREATE_PLAYLIST command followed by video_id."
                 << std::endl;
     } else {
-      videoPlayer.createPlaylist(command[1]);
+      video_player_.createPlaylist(command[1]);
     }
   } else if (command[0] == "ADD_TO_PLAYLIST") {
     if (command.size() != 3) {
@@ -47,7 +48,7 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
                    "name and video_id."
                 << std::endl;
     } else {
-      videoPlayer.addVideoToPlaylist(command[1], command[2]);
+      video_player_.addVideoToPlaylist(command[1], command[2]);
     }
   } else if (command[0] == "REMOVE_FROM_PLAYLIST") {
     if (command.size() != 3) {
@@ -55,7 +56,7 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
                    "playlist name and video_id."
                 << std::endl;
     } else {
-      videoPlayer.removeFromPlaylist(command[1], command[2]);
+      video_player_.removeFromPlaylist(command[1], command[2]);
     }
   } else if (command[0] == "CLEAR_PLAYLIST") {
     if (command.size() != 2) {
@@ -63,7 +64,7 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
           << "Please enter CLEAR_PLAYLIST command followed by a playlist name."
           << std::endl;
     } else {
-      videoPlayer.clearPlaylist(command[1]);
+      video_player_.clearPlaylist(command[1]);
     }
   } else if (command[0] == "DELETE_PLAYLIST") {
     if (command.size() != 2) {
@@ -71,7 +72,7 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
           << "Please enter DELETE_PLAYLIST command followed by a playlist name."
           << std::endl;
     } else {
-      videoPlayer.deletePlaylist(command[1]);
+      video_player_.deletePlaylist(command[1]);
     }
   } else if (command[0] == "SHOW_PLAYLIST") {
     if (command.size() != 2) {
@@ -79,17 +80,17 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
           << "Please enter SHOW_PLAYLIST command followed by a playlist name."
           << std::endl;
     } else {
-      videoPlayer.showPlaylist(command[1]);
+      video_player_.showPlaylist(command[1]);
     }
   } else if (command[0] == "SHOW_ALL_PLAYLISTS") {
-    videoPlayer.showAllPlaylists();
+    video_player_.showAllPlaylists();
   } else if (command[0] == "SEARCH_VIDEOS") {
     if (command.size() != 2) {
       std::cout
           << "Please enter SEARCH_VIDEOS command followed by a search term."
           << std::endl;
     } else {
-      videoPlayer.searchVideos(command[1]);
+      video_player_.searchVideos(command[1]);
     }
   } else if (command[0] == "SEARCH_VIDEOS_WITH_TAG") {
     if (command.size() != 2) {
@@ -97,15 +98,15 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
                    "video tag."
                 << std::endl;
     } else {
-      videoPlayer.searchVideosWithTag(command[1]);
+      video_player_.searchVideosWithTag(command[1]);
     }
   } else if (command[0] == "FLAG_VIDEO") {
     switch (command.size()) {
       case 2:
-        videoPlayer.flagVideo(command[1]);
+        video_player_.flagVideo(command[1]);
         break;
       case 3:
-        videoPlayer.flagVideo(command[1], command[2]);
+        video_player_.flagVideo(command[1], command[2]);
         break;
       default:
         std::cout << "Please enter FLAG_VIDEO command followed by a video_id "
@@ -117,7 +118,7 @@ void CommandParser::executeCommand(std::vector<std::string> command) {
       std::cout << "Please enter ALLOW_VIDEO command followed by a video_id."
                 << std::endl;
     } else {
-      videoPlayer.allowVideo(command[1]);
+      video_player_.allowVideo(command[1]);
     }
   } else if (command[0] == "HELP") {
     getHelp();

--- a/cpp/src/commandparser.h
+++ b/cpp/src/commandparser.h
@@ -10,11 +10,21 @@
  */
 class CommandParser {
  private:
-  VideoPlayer videoPlayer;
+  VideoPlayer video_player_;
+
   void getHelp() const;
 
  public:
   CommandParser(VideoPlayer&& vp);
+
+  // This class is not copyable to avoid expensive copies.
+  CommandParser(CommandParser const&) = delete;
+  CommandParser& operator=(CommandParser const&) = delete;
+
+  // This class is movable.
+  CommandParser(CommandParser&&) = default;
+  CommandParser& operator=(CommandParser&&) = default;
+
   // Executes the given user command.
-  void executeCommand(std::vector<std::string> command);
+  void executeCommand(std::vector<std::string> const& command);
 };

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "commandparser.h"

--- a/cpp/src/video.cpp
+++ b/cpp/src/video.cpp
@@ -1,17 +1,18 @@
 #include "video.h"
 
 #include <iostream>
+#include <utility>
 #include <vector>
 
-Video::Video(std::string&& title, std::string&& videoId,
-             std::vector<std::string>&& tags) {
-  this->title = title;
-  this->videoId = videoId;
-  this->tags = tags;
+Video::Video(std::string&& title, std::string&& video_id,
+             std::vector<std::string>&& tags) :
+  title_(std::move(title)),
+  video_id_(std::move(video_id)),
+  tags_(std::move(tags)) {
 }
 
-std::string const& Video::getTitle() const { return this->title; }
+std::string const& Video::getTitle() const { return title_; }
 
-std::string const& Video::getVideoId() const { return this->videoId; }
+std::string const& Video::getVideoId() const { return video_id_; }
 
-std::vector<std::string> const& Video::getTags() const { return this->tags; }
+std::vector<std::string> const& Video::getTags() const { return tags_; }

--- a/cpp/src/video.h
+++ b/cpp/src/video.h
@@ -8,12 +8,12 @@
  */
 class Video {
  private:
-  std::string title;
-  std::string videoId;
-  std::vector<std::string> tags;
+  std::string title_;
+  std::string video_id_;
+  std::vector<std::string> tags_;
 
  public:
-  Video(std::string&& title, std::string&& videoId,
+  Video(std::string&& title, std::string&& video_id,
         std::vector<std::string>&& tags);
 
   // Returns the title of the video.

--- a/cpp/src/videolibrary.cpp
+++ b/cpp/src/videolibrary.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "helper.h"
@@ -25,7 +26,7 @@ VideoLibrary::VideoLibrary() {
         tags.emplace_back(trim(std::move(tag)));
       }
       Video video = Video(trim(std::move(title)), trim(id), std::move(tags));
-      this->videos.emplace(trim(std::move(id)), std::move(video));
+      videos_.emplace(trim(std::move(id)), std::move(video));
     }
   } else {
     std::cout << "Couldn't find videos.txt" << std::endl;
@@ -34,15 +35,15 @@ VideoLibrary::VideoLibrary() {
 
 std::vector<Video> VideoLibrary::getVideos() const {
   std::vector<Video> result;
-  for (auto const &video : this->videos) {
+  for (auto const &video : videos_) {
     result.emplace_back(video.second);
   }
   return result;
 }
 
-Video const *VideoLibrary::getVideo(std::string videoId) const {
-  auto const found = this->videos.find(videoId);
-  if (found == this->videos.end()) {
+Video const *VideoLibrary::getVideo(std::string const& video_id) const {
+  auto const found = videos_.find(video_id);
+  if (found == videos_.end()) {
     std::cout << "Video not found in video library" << std::endl;
     return nullptr;
   } else {

--- a/cpp/src/videolibrary.h
+++ b/cpp/src/videolibrary.h
@@ -11,10 +11,19 @@
  */
 class VideoLibrary {
  private:
-  std::unordered_map<std::string, Video> videos;
+  std::unordered_map<std::string, Video> videos_;
 
  public:
   VideoLibrary();
+
+  // This class is not copyable to avoid expensive copies.
+  VideoLibrary(VideoLibrary const&) = delete;
+  VideoLibrary& operator=(VideoLibrary const&) = delete;
+
+  // This class is movable.
+  VideoLibrary(VideoLibrary&&) = default;
+  VideoLibrary& operator=(VideoLibrary&&) = default;
+
   std::vector<Video> getVideos() const;
-  Video const *getVideo(std::string videoId) const;
+  Video const *getVideo(std::string const& video_id) const;
 };

--- a/cpp/src/videoplayer.cpp
+++ b/cpp/src/videoplayer.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 void VideoPlayer::numberOfVideos() {
-  std::cout << videoLibrary.getVideos().size() << " videos in the library"
+  std::cout << video_library_.getVideos().size() << " videos in the library"
             << std::endl;
 }
 
@@ -11,7 +11,7 @@ void VideoPlayer::showAllVideos() {
   std::cout << "showAllVideos needs implementation" << std::endl;
 }
 
-void VideoPlayer::playVideo(std::string videoId) {
+void VideoPlayer::playVideo(std::string const& video_id) {
   std::cout << "playVideo needs implementation" << std::endl;
 }
 
@@ -35,16 +35,16 @@ void VideoPlayer::showPlaying() {
   std::cout << "showPlaying needs implementation" << std::endl;
 }
 
-void VideoPlayer::createPlaylist(std::string playlistName) {
+void VideoPlayer::createPlaylist(std::string const& playlist_name) {
   std::cout << "createPlaylist needs implementation" << std::endl;
 }
 
-void VideoPlayer::addVideoToPlaylist(std::string playlistName,
-                                     std::string videoId) {
+void VideoPlayer::addVideoToPlaylist(std::string const& playlist_name,
+                                     std::string const& video_id) {
   std::cout << "addVideoToPlaylist needs implementation" << std::endl;
 }
 
-void VideoPlayer::showPlaylist(std::string playlistName) {
+void VideoPlayer::showPlaylist(std::string const& playlist_name) {
   std::cout << "showPlaylist needs implementation" << std::endl;
 }
 
@@ -52,35 +52,35 @@ void VideoPlayer::showAllPlaylists() {
   std::cout << "showAllPlaylists needs implementation" << std::endl;
 }
 
-void VideoPlayer::removeFromPlaylist(std::string playlistName,
-                                     std::string videoId) {
+void VideoPlayer::removeFromPlaylist(std::string const& playlist_name,
+                                     std::string const& video_id) {
   std::cout << "removeFromPlaylist needs implementation" << std::endl;
 }
 
-void VideoPlayer::clearPlaylist(std::string playlistName) {
+void VideoPlayer::clearPlaylist(std::string const& playlist_name) {
   std::cout << "clearPlaylist needs implementation" << std::endl;
 }
 
-void VideoPlayer::deletePlaylist(std::string playlistName) {
+void VideoPlayer::deletePlaylist(std::string const& playlist_name) {
   std::cout << "deletePlaylist needs implementation" << std::endl;
 }
 
-void VideoPlayer::searchVideos(std::string searchTerm) {
+void VideoPlayer::searchVideos(std::string const& search_term) {
   std::cout << "searchVideos needs implementation" << std::endl;
 }
 
-void VideoPlayer::searchVideosWithTag(std::string videoTag) {
+void VideoPlayer::searchVideosWithTag(std::string const& video_tag) {
   std::cout << "searchVideosWithTag needs implementation" << std::endl;
 }
 
-void VideoPlayer::flagVideo(std::string videoId) {
+void VideoPlayer::flagVideo(std::string const& video_id) {
   std::cout << "flagVideo needs implementation" << std::endl;
 }
 
-void VideoPlayer::flagVideo(std::string videoId, std::string reason) {
+void VideoPlayer::flagVideo(std::string const& video_id, std::string const& reason) {
   std::cout << "flagVideo needs implementation" << std::endl;
 }
 
-void VideoPlayer::allowVideo(std::string videoId) {
+void VideoPlayer::allowVideo(std::string const& video_id) {
   std::cout << "allowVideo needs implementation" << std::endl;
 }

--- a/cpp/src/videoplayer.h
+++ b/cpp/src/videoplayer.h
@@ -9,27 +9,37 @@
  */
 class VideoPlayer {
  private:
-  VideoLibrary videoLibrary;
+  VideoLibrary video_library_;
 
  public:
+  VideoPlayer() = default;
+
+  // This class is not copyable to avoid expensive copies.
+  VideoPlayer(VideoPlayer const&) = delete;
+  VideoPlayer& operator=(VideoPlayer const&) = delete;
+
+  // This class is movable.
+  VideoPlayer(VideoPlayer&&) = default;
+  VideoPlayer& operator=(VideoPlayer&&) = default;
+
   void numberOfVideos();
   void showAllVideos();
-  void playVideo(std::string videoId);
+  void playVideo(std::string const& video_id);
   void playRandomVideo();
   void stopVideo();
   void pauseVideo();
   void continueVideo();
   void showPlaying();
-  void createPlaylist(std::string playlistName);
-  void addVideoToPlaylist(std::string playlistName, std::string videoId);
-  void showPlaylist(std::string playlistName);
+  void createPlaylist(std::string const& playlist_name);
+  void addVideoToPlaylist(std::string const& playlist_name, std::string const& video_id);
+  void showPlaylist(std::string const& playlist_name);
   void showAllPlaylists();
-  void removeFromPlaylist(std::string playlistName, std::string videoId);
-  void clearPlaylist(std::string playlistName);
-  void deletePlaylist(std::string playlistName);
-  void searchVideos(std::string searchTerm);
-  void searchVideosWithTag(std::string videoTag);
-  void flagVideo(std::string videoId);
-  void flagVideo(std::string videoId, std::string reason);
-  void allowVideo(std::string videoId);
+  void removeFromPlaylist(std::string const& playlist_name, std::string const& video_id);
+  void clearPlaylist(std::string const& playlist_name);
+  void deletePlaylist(std::string const& playlist_name);
+  void searchVideos(std::string const& search_term);
+  void searchVideosWithTag(std::string const& video_tag);
+  void flagVideo(std::string const& video_id);
+  void flagVideo(std::string const& video_id, std::string const& reason);
+  void allowVideo(std::string const& video_id);
 };


### PR DESCRIPTION
In several cases it was attempted to move variables into constructors, but the `std::move()` was missing, so the variables were actually copied. I have changed some classes to movable-only to avoid accidental copies.

There were some conflicts between parameter names and member variable names, since the member variables had no additional marking. Since this is a Google challenge, I have renamed the member variable and parameter names to follow the Google C++ Style Guide, which also fixed the conflicts.

Many function parameters were passed by value, even though they were class instances like `std::string` or even `std::vector`. This introduces unnecassary copies and is not a good practice, so I have replaced them by const references.