### PR TITLE
Update README.md

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -68,7 +68,7 @@ mvn test -Dtest=Part4Test
 
 ## Running and Testing from IntelliJ
 To import the project as a Maven project, follow [the official IntelliJ instructions](https://www.jetbrains.com/help/idea/maven-support.html#maven_import_project_start). Alternatively, you should be able to import the project at the java/ folder and IntelliJ will automatically recognize the project as a Maven project.
-Make sure that the project SDK is set to Java 11, [the official IntelliJ instructions on how to set it](https://www.jetbrains.com/help/idea/sdk.html#change-project-sdk).
+Make sure that the project SDK is set to Java 11, [the official IntelliJ instructions on how to set it or download it](https://www.jetbrains.com/help/idea/sdk.html#change-project-sdk). You can use any vendor for JDK 11 if you don't have it already downloaded.
 
 To run the Application, click on the little green play symbol next to `Run`.
 To run the tests, click on the little green double arrow next to the tests class.


### PR DESCRIPTION
Specify that any vendor is fine for downloading JDK 11 and explicitly indicate that the Jetbrains page contains instructions for both downloading and setting jdk 11.